### PR TITLE
Use req.path instead of req.url to ignore url queries

### DIFF
--- a/core/middleware/index.js
+++ b/core/middleware/index.js
@@ -22,7 +22,8 @@ exports.process = function (req, res, next) {
                 delete require.cache[key];
             }
         });
-        var pathToFile = path.join(global.app.get('user'), req.url);
+        var pathToFile = path.join(global.app.get('user'), req.path);
+
         var html;
         try {
             var matchingPattern = /<SourceExample((?:.|\n)*?)>\s*((?:.|\n)+?)\n\s*?<\/SourceExample>/g;


### PR DESCRIPTION
From SourceJS 0.5.6 I use URL params for internal calls (in [Clarify](http://sourcejs.com/specs/example-specs-showcase/dss/?clarify=true&sections=1) for example), which is now broken with React specs. 

I fixed it with replacing full url usage, with just path which is the only actually required thing.
